### PR TITLE
Make broadcasts cleaner, more efficient, and expandable

### DIFF
--- a/PresetBC/PresetBC/Config.cs
+++ b/PresetBC/PresetBC/Config.cs
@@ -17,58 +17,13 @@ namespace PresetBC
         [Description("How long do the broadcasts last?")]
         public ushort BroadcastDuration { get; set; } = 15;
 
-        [Description("What's the shorthand of broadcast 1?")]
-        public string ShorthandBroadcast1 { get; set; } = "Hello World!";
-
-        [Description("What is broadcast 1?")]
-        public string Broadcast1 { get; set; } = "<size=40><color=#ff0000ff><b>Hello, world!</b></color></size> \n <size=25>This is a sample broadcast!</size>";
-
-        [Description("What's the shorthand of broadcast 2?")]
-        public string ShorthandBroadcast2 { get; set; } = "";
-
-        [Description("What is broadcast 2?")]
-        public string Broadcast2 { get; set; } = "";
-
-        [Description("What's the shorthand of broadcast 3?")]
-        public string ShorthandBroadcast3 { get; set; } = "Empty.";
-
-        [Description("What is broadcast 3?")]
-        public string Broadcast3 { get; set; } = "";
-
-        [Description("What's the shorthand of broadcast 4?")]
-        public string ShorthandBroadcast4 { get; set; } = "Empty.";
-
-        [Description("What is broadcast 4?")]
-        public string Broadcast4 { get; set; } = "";
-
-        [Description("What's the shorthand of broadcast 5?")]
-        public string ShorthandBroadcast5 { get; set; } = "Empty.";
-
-        [Description("What is broadcast 5?")]
-        public string Broadcast5 { get; set; } = "";
-
-        [Description("What's the shorthand of broadcast 6?")]
-        public string ShorthandBroadcast6 { get; set; } = "Empty.";
-
-        [Description("What is broadcast 6?")]
-        public string Broadcast6 { get; set; } = "";
-
-        [Description("What's the shorthand of broadcast 7?")]
-        public string ShorthandBroadcast7 { get; set; } = "Empty.";
-
-        [Description("What is broadcast 7?")]
-        public string Broadcast7 { get; set; } = "";
-
-        [Description("What's the shorthand of broadcast 8?")]
-        public string ShorthandBroadcast8 { get; set; } = "Empty.";
-
-        [Description("What is broadcast 8?")]
-        public string Broadcast8 { get; set; } = "";
-
-        [Description("What's the shorthand of broadcast 9?")]
-        public string ShorthandBroadcast9 { get; set; } = "Empty.";
-
-        [Description("What is broadcast 9?")] 
-        public string Broadcast9 { get; set; } = "";
+        [Description("Define your broadcasts here.")]
+		public List<string> Broadcasts = new List<string>() {
+			"Hello World!: <size=40><color=#ff0000ff><b>Hello, world!</b></color></size> \n <size=25>This is a sample broadcast!</size>"
+		};
+		
+		internal List<string[]> GetBroadcasts(){
+			return Broadcasts.Select(bc => bc.Split(new string[]{": "}, 2, StringSplitOptions.None));
+		}
     }
 }

--- a/PresetBC/PresetBC/Config.cs
+++ b/PresetBC/PresetBC/Config.cs
@@ -22,7 +22,7 @@ namespace PresetBC
             "Hello World!: <size=40><color=#ff0000ff><b>Hello, world!</b></color></size> \n <size=25>This is a sample broadcast!</size>"
         };
         
-        internal List<string[]> GetBroadcasts(){
+        internal List<string[]> GetBroadcasts() {
             return Broadcasts.Select(bc => bc.Split(new string[]{": "}, 2, StringSplitOptions.None));
         }
     }

--- a/PresetBC/PresetBC/Config.cs
+++ b/PresetBC/PresetBC/Config.cs
@@ -18,12 +18,12 @@ namespace PresetBC
         public ushort BroadcastDuration { get; set; } = 15;
 
         [Description("Define your broadcasts here.")]
-		public List<string> Broadcasts = new List<string>() {
-			"Hello World!: <size=40><color=#ff0000ff><b>Hello, world!</b></color></size> \n <size=25>This is a sample broadcast!</size>"
-		};
-		
-		internal List<string[]> GetBroadcasts(){
-			return Broadcasts.Select(bc => bc.Split(new string[]{": "}, 2, StringSplitOptions.None));
-		}
+        public List<string> Broadcasts = new List<string>() {
+            "Hello World!: <size=40><color=#ff0000ff><b>Hello, world!</b></color></size> \n <size=25>This is a sample broadcast!</size>"
+        };
+        
+        internal List<string[]> GetBroadcasts(){
+            return Broadcasts.Select(bc => bc.Split(new string[]{": "}, 2, StringSplitOptions.None));
+        }
     }
 }

--- a/PresetBC/PresetBC/EventHandlers.cs
+++ b/PresetBC/PresetBC/EventHandlers.cs
@@ -39,7 +39,7 @@ namespace PresetBC
             }
             else if (ev.Name.StartsWith("pre"))
             {
-                var id = ev.Name.Substring(2);
+                var id = ev.Name.Substring(3);
                 var broadcasts = plugin.Config.GetBroadcasts();
                 
                 if(int.TryParse(id.Trim(), out var index) && index < broadcasts.Count){
@@ -48,9 +48,9 @@ namespace PresetBC
                     return;
                 }
                 
-                var bc = broadcasts.Where(bc => bc[0].Trim().ToLower() == id.Trim().ToLower());
+                var bc = broadcasts.Where(bc => bc[0].Trim().ToLower() == id.Trim().ToLower()).FirstOrDefault();
                 if(bc){
-                    Map.Broadcast(plugin.Config.BroadcastDuration, bc);
+                    Map.Broadcast(plugin.Config.BroadcastDuration, bc[0]);
                     ev.ReplyMessage = "Broadcast Sent.";
                     return;
                 }

--- a/PresetBC/PresetBC/EventHandlers.cs
+++ b/PresetBC/PresetBC/EventHandlers.cs
@@ -22,73 +22,39 @@ namespace PresetBC
         public void OnCommand(SendingRemoteAdminCommandEventArgs ev)
         {
 
-            Player sender = ev.Sender;
+            var sender = ev.Sender;
 
             if (!sender.CheckPermission("pbc.broadcast"))
             {
                 ev.ReplyMessage = ("Permission Denied.");
-            }
-            else {
-                if (ev.Name == "pre")
-                {
-                    ev.ReplyMessage = ("\n1. " + plugin.Config.ShorthandBroadcast1 + "\n" +
-                    "2. " + plugin.Config.ShorthandBroadcast2 + "\n" +
-                    "3. " + plugin.Config.ShorthandBroadcast3 + "\n" +
-                    "4. " + plugin.Config.ShorthandBroadcast4 + "\n" +
-                    "5. " + plugin.Config.ShorthandBroadcast5 + "\n" +
-                    "6. " + plugin.Config.ShorthandBroadcast6 + "\n" +
-                    "7. " + plugin.Config.ShorthandBroadcast7 + "\n" +
-                    "8. " + plugin.Config.ShorthandBroadcast8 + "\n" +
-                    "9. " + plugin.Config.ShorthandBroadcast9);
-                }
-                else if (ev.Name == "pre1" || ev.Name == "pre" + plugin.Config.ShorthandBroadcast1)
-                {
-                    Map.Broadcast(plugin.Config.BroadcastDuration, plugin.Config.Broadcast1);
-                    ev.ReplyMessage = ("Broadcast Sent.");
-                }
-                else if (ev.Name == "pre2" || ev.Name == "pre" + plugin.Config.ShorthandBroadcast2)
-                {
-                    Map.Broadcast(plugin.Config.BroadcastDuration, plugin.Config.Broadcast2);
-                    ev.ReplyMessage = ("Broadcast Sent.");
-                }
-                else if (ev.Name == "pre3" || ev.Name == "pre" + plugin.Config.ShorthandBroadcast3)
-                {
-                    Map.Broadcast(plugin.Config.BroadcastDuration, plugin.Config.Broadcast3);
-                    ev.ReplyMessage = ("Broadcast Sent.");
-                }
-                else if (ev.Name == "pre4" || ev.Name == "pre" + plugin.Config.ShorthandBroadcast4)
-                {
-                    Map.Broadcast(plugin.Config.BroadcastDuration, plugin.Config.Broadcast4);
-                    ev.ReplyMessage = ("Broadcast Sent.");
-                }
-                else if (ev.Name == "pre5" || ev.Name == "pre" + plugin.Config.ShorthandBroadcast5)
-                {
-                    Map.Broadcast(plugin.Config.BroadcastDuration, plugin.Config.Broadcast5);
-                    ev.ReplyMessage = ("Broadcast Sent.");
-                }
-                else if (ev.Name == "pre6" || ev.Name == "pre" + plugin.Config.ShorthandBroadcast6)
-                {
-                    Map.Broadcast(plugin.Config.BroadcastDuration, plugin.Config.Broadcast6);
-                    ev.ReplyMessage = ("Broadcast Sent.");
-                }
-                else if (ev.Name == "pre7" || ev.Name == "pre" + plugin.Config.ShorthandBroadcast7)
-                {
-                    Map.Broadcast(plugin.Config.BroadcastDuration, plugin.Config.Broadcast7);
-                    ev.ReplyMessage = ("Broadcast Sent.");
-                }
-                else if (ev.Name == "pre8" || ev.Name == "pre" + plugin.Config.ShorthandBroadcast8)
-                {
-                    Map.Broadcast(plugin.Config.BroadcastDuration, plugin.Config.Broadcast8);
-                    ev.ReplyMessage = ("Broadcast Sent.");
-                }
-                else if (ev.Name == "pre9" || ev.Name == "pre" + plugin.Config.ShorthandBroadcast9)
-                {
-                    Map.Broadcast(plugin.Config.BroadcastDuration, plugin.Config.Broadcast9);
-                    ev.ReplyMessage = ("Broadcast Sent.");
-                }
-
+				return;
             }
             
+            if (ev.Name == "pre")
+            {
+                ev.ReplyMessage = "";
+				foreach(var bc in plugin.Config.GetBroadcasts()){
+					ev.ReplyMessage += bc[0] + "\n";
+				}
+            }
+            else if (ev.Name.StartsWith("pre"))
+            {
+				var id = ev.Name.Substring(2);
+				var broadcasts = plugin.Config.GetBroadcasts();
+				
+				if(int.TryParse(id.Trim(), out var index) && index < broadcasts.Count){
+					Map.Broadcast(plugin.Config.BroadcastDuration, broadcasts[index][1]);
+					ev.ReplyMessage = "Broadcast Sent.";
+					return;
+				}
+				
+				var bc = broadcasts.Where(bc => bc[0].Trim().ToLower() == id.Trim().ToLower());
+				if(bc){
+					Map.Broadcast(plugin.Config.BroadcastDuration, bc);
+					ev.ReplyMessage = "Broadcast Sent.";
+					return;
+				}
+            }
         }
     }
 }

--- a/PresetBC/PresetBC/EventHandlers.cs
+++ b/PresetBC/PresetBC/EventHandlers.cs
@@ -32,9 +32,11 @@ namespace PresetBC
             
             if (ev.Name == "pre")
             {
-                ev.ReplyMessage = "";
-                foreach(var bc in plugin.Config.GetBroadcasts()){
-                    ev.ReplyMessage += bc[0] + "\n";
+				var broadcasts = plugin.Config.GetBroadcasts();
+				
+                ev.ReplyMessage = "\n";
+                for(var i = 0; i < broadcasts.Count; i++){
+                    ev.ReplyMessage += (i+1) + ". "+ broadcasts[i][0] + "\n";
                 }
             }
             else if (ev.Name.StartsWith("pre"))
@@ -42,13 +44,13 @@ namespace PresetBC
                 var id = ev.Name.Substring(3);
                 var broadcasts = plugin.Config.GetBroadcasts();
                 
-                if(int.TryParse(id.Trim(), out var index) && index < broadcasts.Count){
-                    Map.Broadcast(plugin.Config.BroadcastDuration, broadcasts[index][1]);
+                if(int.TryParse(id.Trim(), out var index) && index <= broadcasts.Count && index > 0){
+                    Map.Broadcast(plugin.Config.BroadcastDuration, broadcasts[index-1][1]);
                     ev.ReplyMessage = "Broadcast Sent.";
                     return;
                 }
                 
-                var bc = broadcasts.Where(bc => bc[0].Trim().ToLower() == id.Trim().ToLower()).FirstOrDefault();
+                var bc = broadcasts.FirstOrDefault(bc => bc[0].Trim().ToLower() == id.Trim().ToLower());
                 if(bc){
                     Map.Broadcast(plugin.Config.BroadcastDuration, bc[0]);
                     ev.ReplyMessage = "Broadcast Sent.";

--- a/PresetBC/PresetBC/EventHandlers.cs
+++ b/PresetBC/PresetBC/EventHandlers.cs
@@ -27,33 +27,33 @@ namespace PresetBC
             if (!sender.CheckPermission("pbc.broadcast"))
             {
                 ev.ReplyMessage = ("Permission Denied.");
-				return;
+                return;
             }
             
             if (ev.Name == "pre")
             {
                 ev.ReplyMessage = "";
-				foreach(var bc in plugin.Config.GetBroadcasts()){
-					ev.ReplyMessage += bc[0] + "\n";
-				}
+                foreach(var bc in plugin.Config.GetBroadcasts()){
+                    ev.ReplyMessage += bc[0] + "\n";
+                }
             }
             else if (ev.Name.StartsWith("pre"))
             {
-				var id = ev.Name.Substring(2);
-				var broadcasts = plugin.Config.GetBroadcasts();
-				
-				if(int.TryParse(id.Trim(), out var index) && index < broadcasts.Count){
-					Map.Broadcast(plugin.Config.BroadcastDuration, broadcasts[index][1]);
-					ev.ReplyMessage = "Broadcast Sent.";
-					return;
-				}
-				
-				var bc = broadcasts.Where(bc => bc[0].Trim().ToLower() == id.Trim().ToLower());
-				if(bc){
-					Map.Broadcast(plugin.Config.BroadcastDuration, bc);
-					ev.ReplyMessage = "Broadcast Sent.";
-					return;
-				}
+                var id = ev.Name.Substring(2);
+                var broadcasts = plugin.Config.GetBroadcasts();
+                
+                if(int.TryParse(id.Trim(), out var index) && index < broadcasts.Count){
+                    Map.Broadcast(plugin.Config.BroadcastDuration, broadcasts[index][1]);
+                    ev.ReplyMessage = "Broadcast Sent.";
+                    return;
+                }
+                
+                var bc = broadcasts.Where(bc => bc[0].Trim().ToLower() == id.Trim().ToLower());
+                if(bc){
+                    Map.Broadcast(plugin.Config.BroadcastDuration, bc);
+                    ev.ReplyMessage = "Broadcast Sent.";
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
Currently, every possible broadcast is defined and more can't be added. This makes the config not very clean, and also requires you use a very efficient string of if elses. This fixes that.

Please note that this is untested, and there are still some issues, which I will post in a separate issue.